### PR TITLE
Remove the loaded flag 

### DIFF
--- a/src/i18n.cr
+++ b/src/i18n.cr
@@ -4,7 +4,6 @@ require "yaml"
 class I18n
   @@load_path = "./"
   @@file = ""
-  @@loaded = false
 
   def self.load_path=(path)
     @@load_path = path
@@ -12,20 +11,15 @@ class I18n
 
   def self.locale=(label)
     @@file = "#{label}.yml"
-    @@loaded = false
+    load_file
   end
 
   def self.load_file
-    unless @@loaded
-      path = File.join([@@load_path, @@file])
-      @@backend = YAML.parse(File.read(path))
-      @@loaded = true
-    end
+    path = File.join([@@load_path, @@file])
+    @@backend = YAML.parse(File.read(path))
   end
 
   def self.translate(key)
-    load_file unless @@loaded
-
     temp = @@backend.not_nil!
     key.split('.').each do |k|
       temp = temp[k]

--- a/src/i18n.cr
+++ b/src/i18n.cr
@@ -19,6 +19,7 @@ class I18n
     unless @@loaded
       path = File.join([@@load_path, @@file])
       @@backend = YAML.parse(File.read(path))
+      @@loaded = true
     end
   end
 


### PR DESCRIPTION
Considering that specific file scenario, there is no need for the loaded flag, or lazy loading. 

I would even consider using a method "language", not a setter, in order to represent the side-effects:

`I18n.language(:en)`:  seems like a property
`I18n.language!(:en)`: has a side-effect

---

It is important to avoid coupling between the `source` and the translation implementation.

`Source` --> `Memory` <--- `Translation`   

Source: File(s) [YAML, XML, JSON, ...], Database[Redis, %SQL, BoJack ☺️]
Memory: After loaded, store the source content in memory for faster access
Translation: Class that accesses the memory to get the content. 

This simple structure would make it easy for future problems, such as pluralization, string replacement, switching locale without having to load from file again ...

@hugoabonizio what do you think?
